### PR TITLE
Detect the latest executor version at build time

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
-### Description
-_Link to the issue you are fixing_.
-_What behavior do you want to change, why, how does your patch achieve the changes?_
-
-### Testing done
-_Describe the testing strategy. Unit and integration tests are expected for any behaviour changes._
 
 ### Reviewer checklist
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,8 +129,6 @@ tasks.register("writeExecutorVersionFile") {
 
         val versionFile = file("$buildDir/generated/resources/version/creek-system-test-executor.version")
 
-        // Todo:
-        println("Writing creek-system-test-executor version: $executorVersion to $versionFile")
         logger.info("Writing creek-system-test-executor version: $executorVersion to $versionFile")
 
         versionFile.parentFile.mkdirs()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,9 +127,12 @@ tasks.register("writeExecutorVersionFile") {
             .findFirst()
             .orElseThrow { RuntimeException("Did not find test creek-system-test-executor jar in:\n${resolved.joinToString("\n")}") }
 
-        logger.info("Writing creek-system-test-executor version:$executorVersion")
-
         val versionFile = file("$buildDir/resources/main/creek-system-test-executor.version")
+
+        // Todo:
+        println("Writing creek-system-test-executor version: $executorVersion to $versionFile")
+        logger.info("Writing creek-system-test-executor version: $executorVersion to $versionFile")
+
         versionFile.parentFile.mkdirs()
         versionFile.writeText(executorVersion)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,7 +127,7 @@ tasks.register("writeExecutorVersionFile") {
             .findFirst()
             .orElseThrow { RuntimeException("Did not find test creek-system-test-executor jar in:\n${resolved.joinToString("\n")}") }
 
-        val versionFile = file("$buildDir/resources/main/creek-system-test-executor.version")
+        val versionFile = file("$buildDir/generated/resources/version/creek-system-test-executor.version")
 
         // Todo:
         println("Writing creek-system-test-executor version: $executorVersion to $versionFile")
@@ -135,6 +135,8 @@ tasks.register("writeExecutorVersionFile") {
 
         versionFile.parentFile.mkdirs()
         versionFile.writeText(executorVersion)
+
+        sourceSets.main.get().output.dir(mapOf("buildBy" to "writeExecutorVersionFile"), versionFile.parentFile)
     }
 }
 

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
@@ -16,10 +16,10 @@
 
 package org.creekservice.api.system.test.gradle.plugin;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Util to load the default executor version from the creek-system-test-executor.version resource in
@@ -37,14 +37,14 @@ public final class ExecutorVersion {
 
     // @VisibleForTesting
     static String loadResource(final String resourceName) {
-        final URL resource = ExecutorVersion.class.getResource(resourceName);
-        if (resource == null) {
-            throw new IllegalStateException("Jar does not contain " + resourceName + " resource");
-        }
+        try (InputStream resource = ExecutorVersion.class.getResourceAsStream(resourceName)) {
+            if (resource == null) {
+                throw new IllegalStateException(
+                        "Jar does not contain " + resourceName + " resource");
+            }
 
-        try {
-            return Files.readString(Paths.get(resource.toURI()));
-        } catch (Exception e) {
+            return new String(resource.readAllBytes(), UTF_8);
+        } catch (final IOException e) {
             throw new RuntimeException("Failed to read " + resourceName + " resource", e);
         }
     }

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Util to load the default executor version from the creek-system-test-executor.version resource in
- * the jar.
+ * Util to load the default executor version from the {@code creek-system-test-executor.version}
+ * resource in the jar.
  */
 public final class ExecutorVersion {
 

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
@@ -20,9 +20,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
-import java.security.CodeSource;
-import java.security.ProtectionDomain;
 
 /**
  * Util to load the default executor version from the {@code creek-system-test-executor.version}
@@ -40,26 +37,6 @@ public final class ExecutorVersion {
 
     // @VisibleForTesting
     static String loadResource(final String resourceName) {
-        // Todo: Debugging test failure:
-        final ProtectionDomain protectionDomain = ExecutorVersion.class.getProtectionDomain();
-        System.err.println("protectionDomain: " + protectionDomain);
-        final CodeSource codeSource = protectionDomain.getCodeSource();
-        System.err.println("codeSource: " + codeSource);
-        System.err.println("location: " + codeSource.getLocation());
-
-        final URL r0 = ExecutorVersion.class.getResource(resourceName);
-        System.err.println("r0: " + r0);
-        final URL r1 = ExecutorVersion.class.getResource("creek-system-test-executor.version");
-        System.err.println("r1: " + r1);
-
-        final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        System.err.println("cp: " + classLoader);
-
-        final URL r2 = classLoader.getResource(resourceName);
-        System.err.println("r2: " + r2);
-        final URL r3 = classLoader.getResource("creek-system-test-executor.version");
-        System.err.println("r3: " + r3);
-
         try (InputStream resource = ExecutorVersion.class.getResourceAsStream(resourceName)) {
             if (resource == null) {
                 throw new IllegalStateException(

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.gradle.plugin;
+
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Util to load the default executor version from the creek-system-test-executor.version resource in
+ * the jar.
+ */
+public final class ExecutorVersion {
+
+    public static final String VERSION_RESOURCE_NAME = "/creek-system-test-executor.version";
+
+    private ExecutorVersion() {}
+
+    public static String defaultExecutorVersion() {
+        return loadResource(VERSION_RESOURCE_NAME);
+    }
+
+    // @VisibleForTesting
+    static String loadResource(final String resourceName) {
+        final URL resource = ExecutorVersion.class.getResource(resourceName);
+        if (resource == null) {
+            throw new IllegalStateException("Jar does not contain " + resourceName + " resource");
+        }
+
+        try {
+            return Files.readString(Paths.get(resource.toURI()));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read " + resourceName + " resource", e);
+        }
+    }
+}

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
@@ -52,6 +52,14 @@ public final class ExecutorVersion {
         final URL r1 = ExecutorVersion.class.getResource("creek-system-test-executor.version");
         System.err.println("r1: " + r1);
 
+        final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+        System.err.println("cp: " + classLoader);
+
+        final URL r2 = classLoader.getResource(resourceName);
+        System.err.println("r2: " + r2);
+        final URL r3 = classLoader.getResource("creek-system-test-executor.version");
+        System.err.println("r3: " + r3);
+
         try (InputStream resource = ExecutorVersion.class.getResourceAsStream(resourceName)) {
             if (resource == null) {
                 throw new IllegalStateException(

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
@@ -20,6 +20,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
 
 /**
  * Util to load the default executor version from the {@code creek-system-test-executor.version}
@@ -37,6 +40,18 @@ public final class ExecutorVersion {
 
     // @VisibleForTesting
     static String loadResource(final String resourceName) {
+        // Todo: Debugging test failure:
+        final ProtectionDomain protectionDomain = ExecutorVersion.class.getProtectionDomain();
+        System.err.println("protectionDomain: " + protectionDomain);
+        final CodeSource codeSource = protectionDomain.getCodeSource();
+        System.err.println("codeSource: " + codeSource);
+        System.err.println("location: " + codeSource.getLocation());
+
+        final URL r0 = ExecutorVersion.class.getResource(resourceName);
+        System.err.println("r0: " + r0);
+        final URL r1 = ExecutorVersion.class.getResource("creek-system-test-executor.version");
+        System.err.println("r1: " + r1);
+
         try (InputStream resource = ExecutorVersion.class.getResourceAsStream(resourceName)) {
             if (resource == null) {
                 throw new IllegalStateException(

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestPlugin.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestPlugin.java
@@ -16,6 +16,7 @@
 
 package org.creekservice.api.system.test.gradle.plugin;
 
+import static org.creekservice.api.system.test.gradle.plugin.ExecutorVersion.defaultExecutorVersion;
 
 import java.time.Duration;
 import java.util.List;
@@ -85,7 +86,7 @@ public final class SystemTestPlugin implements Plugin<Project> {
         cfg.setCanBeResolved(true);
         cfg.setDescription("Dependency for the system test executor");
 
-        final String pluginDep = "org.creek:creek-system-test-executor:+";
+        final String pluginDep = "org.creek:creek-system-test-executor:" + defaultExecutorVersion();
         final DependencyHandler projectDeps = project.getDependencies();
         cfg.defaultDependencies(deps -> deps.add(projectDeps.create(pluginDep)));
 

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
@@ -39,6 +39,13 @@ class ExecutorVersionTest {
                                         .resolve(
                                                 "resources/main/creek-system-test-executor.version")));
 
+        System.err.println(
+                "resource file exists: "
+                        + Files.isRegularFile(
+                                TestPaths.moduleRoot("build")
+                                        .resolve(
+                                                "generated/resources/version/creek-system-test-executor.version")));
+
         assertThat(defaultExecutorVersion(), is(not("")));
     }
 

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.gradle.plugin;
+
+import static org.creekservice.api.system.test.gradle.plugin.ExecutorVersion.defaultExecutorVersion;
+import static org.creekservice.api.system.test.gradle.plugin.ExecutorVersion.loadResource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ExecutorVersionTest {
+
+    @Test
+    void shouldLoadVersion() {
+        assertThat(defaultExecutorVersion(), is(not("")));
+    }
+
+    @Test
+    void shouldThrowIfResourceNotFound() {
+        // When:
+        final Exception e =
+                assertThrows(IllegalStateException.class, () -> loadResource("wont_find_me"));
+
+        // Then:
+        assertThat(e.getMessage(), is("Jar does not contain wont_find_me resource"));
+    }
+}

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
@@ -23,12 +23,22 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.file.Files;
+import org.creek.api.test.util.TestPaths;
 import org.junit.jupiter.api.Test;
 
 class ExecutorVersionTest {
 
     @Test
     void shouldLoadVersion() {
+        // Todo: Test failuring debugging:
+        System.err.println(
+                "resource file exists: "
+                        + Files.isRegularFile(
+                                TestPaths.moduleRoot("build")
+                                        .resolve(
+                                                "resources/main/creek-system-test-executor.version")));
+
         assertThat(defaultExecutorVersion(), is(not("")));
     }
 

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
@@ -23,29 +23,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.file.Files;
-import org.creek.api.test.util.TestPaths;
 import org.junit.jupiter.api.Test;
 
 class ExecutorVersionTest {
 
     @Test
     void shouldLoadVersion() {
-        // Todo: Test failuring debugging:
-        System.err.println(
-                "resource file exists: "
-                        + Files.isRegularFile(
-                                TestPaths.moduleRoot("build")
-                                        .resolve(
-                                                "resources/main/creek-system-test-executor.version")));
-
-        System.err.println(
-                "resource file exists: "
-                        + Files.isRegularFile(
-                                TestPaths.moduleRoot("build")
-                                        .resolve(
-                                                "generated/resources/version/creek-system-test-executor.version")));
-
         assertThat(defaultExecutorVersion(), is(not("")));
     }
 

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTaskTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTaskTest.java
@@ -17,6 +17,7 @@
 package org.creekservice.api.system.test.gradle.plugin.task;
 
 import static org.creek.api.test.util.coverage.CodeCoverage.codeCoverageCmdLineArg;
+import static org.creekservice.api.system.test.gradle.plugin.ExecutorVersion.defaultExecutorVersion;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
@@ -106,6 +107,23 @@ class SystemTestTaskTest {
                                 + projectDir.resolve("build/test-results/system-test")));
         assertThat(result.getOutput(), containsString("--verifier-timeout-seconds=60"));
         assertThat(result.getOutput(), containsString("--include-suites=.*"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"kotlin", "groovy"})
+    void shouldExecuteWithDefaultVersion(final String flavour) {
+        // Given:
+        givenProject(flavour + "/default");
+
+        // When:
+
+        final BuildResult result = executeTask(ExpectedOutcome.PASS);
+
+        // Then:
+        assertThat(result.task(TASK_NAME).getOutcome(), is(SUCCESS));
+        assertThat(
+                result.getOutput(),
+                containsString("SystemTestExecutor: " + defaultExecutorVersion()));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description

fixes: https://github.com/creek-service/creek-system-test-gradle-plugin/issues/17

Adds a gradle task to determine the latest executor version at build time and to write this version to a resource file.

The plugin then loads this resource file and uses this as the default executor version.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended