### PR TITLE
Bring system test plugin inline with json schema plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     testImplementation("com.google.guava:guava-testlib:$guavaVersion")
     testImplementation("org.apache.logging.log4j:log4j-api:$log4jVersion")
     testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
-    testImplementation("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion")
+    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     // The following dependency is only added to trigger the Github Dependency Bot to update creekSystemTestVersion:
     testRuntimeOnly("org.creekservice:creek-system-test-executor:$creekSystemTestVersion")

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestExtension.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestExtension.java
@@ -53,11 +53,17 @@ public abstract class SystemTestExtension {
      */
     public abstract Property<String> getSuitePathPattern();
 
-    /** @return list of additional arguments to pass to the test executor */
+    /**
+     * @return list of additional arguments to pass to the test executor
+     *     <p>See https://github.com/creek-service/creek-system-test/tree/main/executor for more
+     *     info.
+     */
     public abstract ListProperty<String> getExtraArguments();
 
     /**
-     * Set additional args to use when running system tests.
+     * Set additional args to pass to the test executor.
+     *
+     * <p>See https://github.com/creek-service/creek-system-test/tree/main/executor for more info.
      *
      * @param args the extra args to use when running system tests.
      */

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestPlugin.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestPlugin.java
@@ -33,7 +33,7 @@ import org.gradle.testing.base.plugins.TestingBasePlugin;
 public final class SystemTestPlugin implements Plugin<Project> {
 
     public static final String EXTENSION_NAME = "systemTest";
-    public static final String CONFIGURATION_NAME = "systemTest";
+    public static final String CONFIGURATION_NAME = "systemTestExecutor";
     public static final String SYSTEM_TEST_TASK_NAME = "systemTest";
     public static final String GROUP_NAME = "Creek";
     public static final String DEFAULT_TESTS_DIR_NAME = "src/system-test";
@@ -41,6 +41,8 @@ public final class SystemTestPlugin implements Plugin<Project> {
             TestingBasePlugin.TEST_RESULTS_DIR_NAME + "/system-test";
     public static final Duration DEFAULT_EXPECTATION_TIMEOUT = Duration.ofMinutes(1);
     public static final String DEFAULT_SUITES_PATTERN = ".*";
+    public static final String EXECUTOR_DEP_GROUP_NAME = "org.creekservice";
+    public static final String EXECUTOR_DEP_ARTEFACT_NAME = "creek-system-test-executor";
 
     @Override
     public void apply(final Project project) {
@@ -91,10 +93,14 @@ public final class SystemTestPlugin implements Plugin<Project> {
         cfg.setTransitive(true);
         cfg.setCanBeConsumed(false);
         cfg.setCanBeResolved(true);
-        cfg.setDescription("Dependency for the system test executor");
+        cfg.setDescription("Dependency for the Creek system test executor");
 
         final String pluginDep =
-                "org.creekservice:creek-system-test-executor:" + defaultExecutorVersion();
+                EXECUTOR_DEP_GROUP_NAME
+                        + ":"
+                        + EXECUTOR_DEP_ARTEFACT_NAME
+                        + ":"
+                        + defaultExecutorVersion();
         final DependencyHandler projectDeps = project.getDependencies();
         cfg.defaultDependencies(deps -> deps.add(projectDeps.create(pluginDep)));
 

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTask.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTask.java
@@ -16,6 +16,8 @@
 
 package org.creekservice.api.system.test.gradle.plugin.task;
 
+import static org.creekservice.api.system.test.gradle.plugin.SystemTestPlugin.EXECUTOR_DEP_ARTEFACT_NAME;
+import static org.creekservice.api.system.test.gradle.plugin.SystemTestPlugin.EXECUTOR_DEP_GROUP_NAME;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +25,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.creekservice.api.system.test.gradle.plugin.SystemTestPlugin;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -114,12 +117,12 @@ public abstract class SystemTestTask extends DefaultTask {
 
         final Optional<Dependency> executorDep =
                 configuration.getDependencies().stream()
-                        .filter(dep -> "org.creekservice".equals(dep.getGroup()))
-                        .filter(dep -> "creek-system-test-executor".equals(dep.getName()))
+                        .filter(dep -> EXECUTOR_DEP_GROUP_NAME.equals(dep.getGroup()))
+                        .filter(dep -> EXECUTOR_DEP_ARTEFACT_NAME.equals(dep.getName()))
                         .findFirst();
 
         if (executorDep.isEmpty()) {
-            throw new MissingExecutorDependency();
+            throw new MissingExecutorDependencyException();
         }
 
         getLogger().debug("Using system test executor version: " + executorDep.get().getVersion());
@@ -142,13 +145,16 @@ public abstract class SystemTestTask extends DefaultTask {
         return arguments;
     }
 
-    private static final class MissingExecutorDependency extends RuntimeException {
+    private static final class MissingExecutorDependencyException extends GradleException {
 
-        MissingExecutorDependency() {
+        MissingExecutorDependencyException() {
             super(
                     "No system test executor dependency found in "
                             + SystemTestPlugin.CONFIGURATION_NAME
-                            + " configuration.");
+                            + " configuration. Please ensure the configuration contains "
+                            + EXECUTOR_DEP_GROUP_NAME
+                            + ":"
+                            + EXECUTOR_DEP_ARTEFACT_NAME);
         }
     }
 }

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTaskTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTaskTest.java
@@ -29,14 +29,16 @@ import static org.hamcrest.Matchers.notNullValue;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.creekservice.api.test.util.TestPaths;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.cartesian.ArgumentSets;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
-import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.MethodFactory;
 
 @SuppressWarnings("ConstantConditions")
 class SystemTestTaskTest {
@@ -58,9 +60,8 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
-    void shouldSkipIfTestDirectoryDoesNotExist(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldSkipIfTestDirectoryDoesNotExist(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/empty");
 
@@ -72,9 +73,8 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
-    void shouldSkipIfTestDirectoryEmpty(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldSkipIfTestDirectoryEmpty(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/empty");
         givenDirectory(projectDir.resolve("src/system-test"));
@@ -87,9 +87,8 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
-    void shouldExecuteWithDefaults(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldExecuteWithDefaults(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/default");
 
@@ -108,29 +107,15 @@ class SystemTestTaskTest {
                                 + projectDir.resolve("build/test-results/system-test")));
         assertThat(result.getOutput(), containsString("--verifier-timeout-seconds=60"));
         assertThat(result.getOutput(), containsString("--include-suites=.*"));
-    }
 
-    @CartesianTest
-    void shouldExecuteWithDefaultVersion(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
-        // Given:
-        givenProject(flavour + "/default");
-
-        // When:
-        final BuildResult result = executeTask(ExpectedOutcome.PASS, gradleVersion);
-
-        // Then:
-        assertThat(result.task(TASK_NAME).getOutcome(), is(SUCCESS));
         assertThat(
                 result.getOutput(),
                 containsString("SystemTestExecutor: " + defaultExecutorVersion()));
     }
 
     @CartesianTest
-    void shouldExecuteWithSpecificVersion(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldExecuteWithSpecificVersion(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/specific_version");
 
@@ -143,9 +128,8 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
-    void shouldExecuteWithCustomProperties(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldExecuteWithCustomProperties(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/fully_configured");
 
@@ -165,9 +149,9 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
+    @MethodFactory("flavoursAndVersions")
     void shouldFailIfSystemTestConfigurationDoesNotContainExecutor(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+            final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/missing_executor_dep");
 
@@ -179,13 +163,12 @@ class SystemTestTaskTest {
         assertThat(
                 result.getOutput(),
                 containsString(
-                        "No system test executor dependency found in systemTest configuration."));
+                        "No system test executor dependency found in systemTestExecutor configuration."));
     }
 
     @CartesianTest
-    void shouldFailOnBadConfig(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldFailOnBadConfig(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/invalid_config");
 
@@ -198,9 +181,8 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
-    void shouldExecuteWithOptions(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldExecuteWithOptions(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/empty");
         givenTestSuite();
@@ -221,9 +203,8 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
-    void shouldRunSystemTestAsPartOfCheckTask(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldRunSystemTestAsPartOfCheckTask(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/default");
 
@@ -236,9 +217,8 @@ class SystemTestTaskTest {
     }
 
     @CartesianTest
-    void shouldDeleteOutputDirectoryOnClean(
-            @Values(strings = {"kotlin", "groovy"}) final String flavour,
-            @Values(strings = {"6.4", "6.9.2", "7.0", "7.3", "7.4.2"}) final String gradleVersion) {
+    @MethodFactory("flavoursAndVersions")
+    void shouldDeleteOutputDirectoryOnClean(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/default");
         final Path resultsDir =
@@ -310,5 +290,13 @@ class SystemTestTaskTest {
                     projectDir.resolve("gradle.properties"),
                     "org.gradle.jvmargs=" + String.join(" ", options));
         }
+    }
+
+    @SuppressWarnings("unused") // Invoked by reflection
+    private static ArgumentSets flavoursAndVersions() {
+        final Collection<?> flavours = List.of("kotlin", "groovy");
+        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0", "7.3", "7.4.2");
+        return ArgumentSets.argumentsForFirstParameter(flavours)
+                .argumentsForNextParameter(gradleVersions);
     }
 }

--- a/src/test/resources/projects/functional/groovy/missing_executor_dep/build.gradle
+++ b/src/test/resources/projects/functional/groovy/missing_executor_dep/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 dependencies {
-    systemTest 'org.apache.logging.log4j:log4j-api:+'
+    systemTestExecutor 'org.apache.logging.log4j:log4j-api:+'
 }
 
 systemTest {

--- a/src/test/resources/projects/functional/groovy/specific_version/build.gradle
+++ b/src/test/resources/projects/functional/groovy/specific_version/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 dependencies {
-    systemTest 'org.creekservice:creek-system-test-executor:0.2.0-SNAPSHOT'
+    systemTestExecutor 'org.creekservice:creek-system-test-executor:0.2.0-SNAPSHOT'
 }
 
 systemTest {

--- a/src/test/resources/projects/functional/kotlin/missing_executor_dep/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/missing_executor_dep/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 dependencies {
     // Not an executor dependency!
-    systemTest("org.apache.logging.log4j:log4j-api:+")
+    systemTestExecutor("org.apache.logging.log4j:log4j-api:+")
 }
 
 systemTest {

--- a/src/test/resources/projects/functional/kotlin/specific_version/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/specific_version/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 }
 
 dependencies {
-    systemTest("org.creekservice:creek-system-test-executor:0.2.0-SNAPSHOT")
+    systemTestExecutor("org.creekservice:creek-system-test-executor:0.2.0-SNAPSHOT")
 }
 
 systemTest {


### PR DESCRIPTION
Apply back lessons learned from json schema plugin to this system test plugin

- renamed `systemTest` configuration to `systemTestExecutor`, as they'll later be `systemTestComponent` and `systemTestExtension`.
- make use of `@CartesianTest.MethodFactory` to remove duplication in test code.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended