### PR TITLE
Fix issue with corrupted Jacoco coverage file

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '13'
+          java-version: '12'
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,9 +29,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew
-        run: |
-          chmod +x gradlew
-          ./gradlew --version
+        run: chmod +x gradlew
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '13'
+          java-version: '11'
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '12'
+          java-version: '13'
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,7 +36,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew check coveralls
+        run: |
+          ./gradlew check
+          pgrep -fl '.*GradleDaemon.*'
+          pkill -f '.*GradleDaemon.*'
+          pgrep -fl '.*GradleDaemon.*'
+          ./gradlew coveralls
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish == 'true'
         run:  |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '15'
+          java-version: '14'
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '15'
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '14'
+          java-version: '13'
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,9 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: |
+          chmod +x gradlew
+          ./gradlew --version
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,9 +36,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           ./gradlew check
-          pgrep -fl '.*GradleDaemon.*'
           pkill -f '.*GradleDaemon.*'
-          pgrep -fl '.*GradleDaemon.*'
           ./gradlew coveralls
       - name: Publish
         if: github.event_name == 'push' || github.event.inputs.publish == 'true'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -196,6 +196,7 @@ publishing {
 
 tasks.register("coverage") {
     group = "coverage"
+    description = "Calculate coverage statistics"
     dependsOn("jacocoTestReport")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,6 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
     testImplementation("org.hamcrest:hamcrest-core:$hamcrestVersion")
     testImplementation("com.google.guava:guava-testlib:$guavaVersion")
-    testImplementation("org.apache.logging.log4j:log4j-api:$log4jVersion")
     testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
     testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -327,8 +327,7 @@ class SystemTestTest {
             final ExpectedOutcome expectedOutcome,
             final String gradleVersion,
             final String... additionalArgs) {
-        final List<String> args =
-                new ArrayList<>(List.of(INIT_SCRIPT, "--no-daemon", "--stacktrace", taskName));
+        final List<String> args = new ArrayList<>(List.of(INIT_SCRIPT, "--stacktrace", taskName));
         args.addAll(List.of(additionalArgs));
 
         final GradleRunner runner =
@@ -362,8 +361,8 @@ class SystemTestTest {
 
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
-        final Collection<?> flavours = List.of("kotlin", "groovy");
-        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0", "7.4.2");
+        final Collection<?> flavours = List.of("kotlin"); //  , "groovy");
+        final Collection<?> gradleVersions = List.of("6.4"); //  , "6.9.2", "7.0", "7.4.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
                 .argumentsForNextParameter(gradleVersions);
     }

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -64,7 +64,7 @@ class SystemTestTest {
     @BeforeEach
     void setUp() throws Exception {
         projectDir = projectDir.toRealPath();
-        //writeGradleProperties();
+        // writeGradleProperties();
     }
 
     @CartesianTest

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -64,7 +64,7 @@ class SystemTestTest {
     @BeforeEach
     void setUp() throws Exception {
         projectDir = projectDir.toRealPath();
-        writeGradleProperties();
+        //writeGradleProperties();
     }
 
     @CartesianTest

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -58,13 +58,13 @@ class SystemTestTest {
 
     private static final String TASK_NAME = ":systemTest";
     private static final String INIT_SCRIPT = "--init-script=" + TEST_DIR.resolve("init.gradle");
-    private static final List<String> GRADLE_VERSIONS = List.of("6.4", "6.9.2", "7.0", "7.4.2");
 
     @TempDir private Path projectDir;
 
     @BeforeEach
     void setUp() throws Exception {
         projectDir = projectDir.toRealPath();
+        writeGradleProperties();
     }
 
     @CartesianTest
@@ -327,9 +327,8 @@ class SystemTestTest {
             final ExpectedOutcome expectedOutcome,
             final String gradleVersion,
             final String... additionalArgs) {
-        writeGradleProperties(gradleVersion);
-
-        final List<String> args = new ArrayList<>(List.of(INIT_SCRIPT, "--stacktrace", taskName));
+        final List<String> args =
+                new ArrayList<>(List.of(INIT_SCRIPT, "--no-daemon", "--stacktrace", taskName));
         args.addAll(List.of(additionalArgs));
 
         final GradleRunner runner =
@@ -346,13 +345,9 @@ class SystemTestTest {
         return result;
     }
 
-    private void writeGradleProperties(final String gradleVersion) {
+    private void writeGradleProperties() {
         final List<String> options = new ArrayList<>(3);
-
-        if (gradleVersion.equals(latestGradleVersion())) {
-            // Minimise how many runs are added to code coverage to minimise chances of corrupting the coverage file:
-            codeCoverageCmdLineArg(BUILD_DIR).ifPresent(options::add);
-        }
+        codeCoverageCmdLineArg(BUILD_DIR).ifPresent(options::add);
 
         if (DEBUG) {
             options.addAll(remoteDebugArguments());
@@ -365,14 +360,11 @@ class SystemTestTest {
         }
     }
 
-    private static String latestGradleVersion() {
-        return GRADLE_VERSIONS.get(GRADLE_VERSIONS.size() - 1);
-    }
-
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
         final Collection<?> flavours = List.of("kotlin", "groovy");
+        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0", "7.4.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
-                .argumentsForNextParameter(GRADLE_VERSIONS);
+                .argumentsForNextParameter(gradleVersions);
     }
 }

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -350,6 +350,7 @@ class SystemTestTest {
         final List<String> options = new ArrayList<>(3);
 
         if (gradleVersion.equals(latestGradleVersion())) {
+            // Minimise how many runs are added to code coverage to minimise chances of corrupting the coverage file:
             codeCoverageCmdLineArg(BUILD_DIR).ifPresent(options::add);
         }
 

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -362,7 +362,7 @@ class SystemTestTest {
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
         final Collection<?> flavours = List.of("kotlin", "groovy");
-        final Collection<?> gradleVersions = List.of("6.4"); //  , "6.9.2", "7.0", "7.4.2");
+        final Collection<?> gradleVersions = List.of("6.4", "6.9.2"); //  , "7.0", "7.4.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
                 .argumentsForNextParameter(gradleVersions);
     }

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -362,7 +362,7 @@ class SystemTestTest {
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
         final Collection<?> flavours = List.of("kotlin", "groovy");
-        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0"); //, "7.4.2");
+        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0", "7.4.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
                 .argumentsForNextParameter(gradleVersions);
     }

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -58,13 +58,13 @@ class SystemTestTest {
 
     private static final String TASK_NAME = ":systemTest";
     private static final String INIT_SCRIPT = "--init-script=" + TEST_DIR.resolve("init.gradle");
+    private static final List<String> GRADLE_VERSIONS = List.of("6.4", "6.9.2", "7.0", "7.4.2");
 
     @TempDir private Path projectDir;
 
     @BeforeEach
     void setUp() throws Exception {
         projectDir = projectDir.toRealPath();
-        // writeGradleProperties();
     }
 
     @CartesianTest
@@ -327,6 +327,8 @@ class SystemTestTest {
             final ExpectedOutcome expectedOutcome,
             final String gradleVersion,
             final String... additionalArgs) {
+        writeGradleProperties(gradleVersion);
+
         final List<String> args = new ArrayList<>(List.of(INIT_SCRIPT, "--stacktrace", taskName));
         args.addAll(List.of(additionalArgs));
 
@@ -344,9 +346,12 @@ class SystemTestTest {
         return result;
     }
 
-    private void writeGradleProperties() {
+    private void writeGradleProperties(final String gradleVersion) {
         final List<String> options = new ArrayList<>(3);
-        codeCoverageCmdLineArg(BUILD_DIR).ifPresent(options::add);
+
+        if (gradleVersion.equals(latestGradleVersion())) {
+            codeCoverageCmdLineArg(BUILD_DIR).ifPresent(options::add);
+        }
 
         if (DEBUG) {
             options.addAll(remoteDebugArguments());
@@ -359,11 +364,14 @@ class SystemTestTest {
         }
     }
 
+    private static String latestGradleVersion() {
+        return GRADLE_VERSIONS.get(GRADLE_VERSIONS.size() - 1);
+    }
+
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
         final Collection<?> flavours = List.of("kotlin", "groovy");
-        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0", "7.4.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
-                .argumentsForNextParameter(gradleVersions);
+                .argumentsForNextParameter(GRADLE_VERSIONS);
     }
 }

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -361,7 +361,7 @@ class SystemTestTest {
 
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
-        final Collection<?> flavours = List.of("kotlin"); //  , "groovy");
+        final Collection<?> flavours = List.of("kotlin", "groovy");
         final Collection<?> gradleVersions = List.of("6.4"); //  , "6.9.2", "7.0", "7.4.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
                 .argumentsForNextParameter(gradleVersions);

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/task/SystemTestTest.java
@@ -362,7 +362,7 @@ class SystemTestTest {
     @SuppressWarnings("unused") // Invoked by reflection
     private static ArgumentSets flavoursAndVersions() {
         final Collection<?> flavours = List.of("kotlin", "groovy");
-        final Collection<?> gradleVersions = List.of("6.4", "6.9.2"); //  , "7.0", "7.4.2");
+        final Collection<?> gradleVersions = List.of("6.4", "6.9.2", "7.0"); //, "7.4.2");
         return ArgumentSets.argumentsForFirstParameter(flavours)
                 .argumentsForNextParameter(gradleVersions);
     }


### PR DESCRIPTION
Builds keep failing with:

```
* What went wrong:
Execution failed for task ':jacocoTestReport'.
> Unable to read execution data file /home/runner/work/creek-system-test-gradle-plugin/creek-system-test-gradle-plugin/build/jacoco/test.exec
```

Not exactly sure what is wrong with the test.exec file, but internet searches suggest it may be truncated due to JVMs exiting prematurely.

Bumping Java version to see if this fixes the issue

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended