### PR TITLE
Avoid calling executor with empty debug args

### DIFF
--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
@@ -309,15 +309,25 @@ public abstract class SystemTest extends DefaultTask {
             return List.of();
         }
 
-        return List.of(
-                "--debug-service-port=" + getDebugBaseServicePort().get(),
-                "--debug-service=" + String.join(",", getDebugServiceNames().get()),
-                "--debug-service-instance="
-                        + String.join(",", getDebugServiceInstanceNames().get()),
+        final List<String> args = new ArrayList<>();
+        args.add("--debug-service-port=" + getDebugBaseServicePort().get());
+        args.add(
                 "--mount-read-only="
                         + debugPrepareTask.getMountDirectory().get()
                         + "="
                         + CONTAINER_DEBUG_MOUNT);
+
+        final String services = String.join(",", getDebugServiceNames().get());
+        if (!services.isBlank()) {
+            args.add("--debug-service=" + services);
+        }
+
+        final String instances = String.join(",", getDebugServiceInstanceNames().get());
+        if (!instances.isBlank()) {
+            args.add("--debug-service-instance=" + instances);
+        }
+
+        return args;
     }
 
     private List<String> coverageArguments() {

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
@@ -232,6 +232,8 @@ class SystemTestTest extends TaskTestBase {
         assertThat(result.task(TASK_NAME).getOutcome(), is(SUCCESS));
         assertThat(result.getOutput(), containsString("--verifier-timeout-seconds=76"));
         assertThat(result.getOutput(), containsString("--include-suites=.*cli.*"));
+        assertThat(result.getOutput(), containsString("--debug-service=<Not Set>"));
+        assertThat(result.getOutput(), containsString("--debug-service-instance=<Not Set>"));
     }
 
     @CartesianTest
@@ -298,6 +300,51 @@ class SystemTestTest extends TaskTestBase {
                         "--env=JAVA_TOOL_OPTIONS="
                             + "-javaagent:/opt/creek/mounts/debug/attachme-agent-1.2.3.jar=host:host.docker.internal,port:7857"
                             + " -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${SERVICE_DEBUG_PORT}"));
+    }
+
+    @CartesianTest
+    @MethodFactory("flavoursAndVersions")
+    void shouldExecuteWithDebugOptionsJustService(
+            final String flavour, final String gradleVersion) {
+        // Given:
+        givenProject(flavour + "/debug_options");
+
+        // When:
+        final BuildResult result =
+                executeTask(
+                        ExpectedOutcome.PASS,
+                        gradleVersion,
+                        "--extra-argument=--echo-only",
+                        "--debug-service=service-a,service-b");
+
+        // Then:
+        assertThat(result.task(TASK_NAME).getOutcome(), is(SUCCESS));
+        assertThat(result.getOutput(), containsString("--debug-service=service-a,service-b"));
+        assertThat(result.getOutput(), containsString("--debug-service-instance=<Not Set>"));
+    }
+
+    @CartesianTest
+    @MethodFactory("flavoursAndVersions")
+    void shouldExecuteWithDebugOptionsJustInstance(
+            final String flavour, final String gradleVersion) {
+        // Given:
+        givenProject(flavour + "/debug_options");
+
+        // When:
+        final BuildResult result =
+                executeTask(
+                        ExpectedOutcome.PASS,
+                        gradleVersion,
+                        "--extra-argument=--echo-only",
+                        "--debug-service-instance=instance-c",
+                        "--debug-service-instance=instance-d");
+
+        // Then:
+        assertThat(result.task(TASK_NAME).getOutcome(), is(SUCCESS));
+        assertThat(result.getOutput(), containsString("--debug-service=<Not Set>"));
+        assertThat(
+                result.getOutput(),
+                containsString("--debug-service-instance=instance-c,instance-d"));
     }
 
     @CartesianTest


### PR DESCRIPTION
If you supply a service name to debug, or just a service instance to debug, the plugin was passing the other args with an empty value.

For example, setting a service name to debug would result in the plugin passing `--debug-service-instance=`, i.e. an empty instance list.

Let's avoid that and just not set the argument if the list is empty.

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
