### PR TITLE
Use new debug env

### DIFF
--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
@@ -287,9 +287,8 @@ public abstract class SystemTest extends DefaultTask {
     private List<String> arguments() {
         final List<String> arguments = new ArrayList<>();
         arguments.addAll(commonArguments());
-        arguments.addAll(debugArguments());
         arguments.addAll(coverageArguments());
-        arguments.addAll(javaToolOptionsArgument());
+        arguments.addAll(debugArguments());
         arguments.addAll(getExtraArguments().get());
         return arguments;
     }
@@ -327,6 +326,11 @@ public abstract class SystemTest extends DefaultTask {
             args.add("--debug-service-instance=" + instances);
         }
 
+        final String jto = javaToolOptions(true);
+        if (!jto.isBlank()) {
+            args.add("--debug-env=" + jto);
+        }
+
         return args;
     }
 
@@ -337,19 +341,26 @@ public abstract class SystemTest extends DefaultTask {
             return List.of();
         }
 
-        return ext.mountOptions();
+        final List<String> args = new ArrayList<>(ext.mountOptions());
+        final String jto = javaToolOptions(false);
+        if (!jto.isBlank()) {
+            args.add("--env=" + jto);
+        }
+        return args;
     }
 
-    private List<String> javaToolOptionsArgument() {
+    private String javaToolOptions(final boolean debug) {
         final List<String> options = new ArrayList<>(2);
-        options.add(debugJavaToolOptions());
+        if (debug) {
+            options.add(debugJavaToolOptions());
+        }
         options.add(coverageJavaToolOptions());
         options.removeIf(String::isEmpty);
         if (options.isEmpty()) {
-            return List.of();
+            return "";
         }
 
-        return List.of("--env=JAVA_TOOL_OPTIONS=\"" + String.join(" ", options) + "\"");
+        return "JAVA_TOOL_OPTIONS=\"" + String.join(" ", options) + "\"";
     }
 
     private String debugJavaToolOptions() {


### PR DESCRIPTION
Enhance the plugin to make use of the new `--debug-env` option supported by the system test executor to pass in the `JAVA_TOOL_OPTIONS` required for supporting debugging of services.

This fixes a bug around debugging when there is more than one service-under-test in the test suite. Any service _not_ being debugged would fail to start as its `JAVA_TOOL_OPTIONS` incorrectly included the debug agent _and_ the agent line still had a placeholder for the debug port.

A workaround for this bug was to debug all services when you need to debug any.

**BREAKING CHANGE**: this is a braking change, not compatible with previous versions of the system test executor.  However, still in Alpha, so such changes allowed.

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
