### PR TITLE
Latest conventions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    if: ${{ github.run_number != 1 }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -14,3 +14,6 @@
  * limitations under the License.
  */
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+}

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -19,12 +19,12 @@
  *
  * <p>Apply to all java modules, usually excluding the root project in multi-module sets.
  *
- * <p>Version: 1.7
+ * <p>Version: 1.8
+ *  - 1.8: Tweak test config to reduce build speed.
  *  - 1.7: Switch to setting Java version via toolchain
  *  - 1.6: Remove GitHub packages for snapshots
  *  - 1.5: Add filters to exclude generated sources
  *  - 1.4: Add findsecbugs-plugin
- *  - 1.3: Fail on warnings for test code too.
  */
 
 plugins {
@@ -70,8 +70,8 @@ tasks.withType<JavaCompile> {
 
 tasks.test {
     useJUnitPlatform()
-    setForkEvery(1)
-    maxParallelForks = 4
+    setForkEvery(5)
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
     testLogging {
         showStandardStreams = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
@@ -117,17 +117,23 @@ if (rootProject.name != project.name) {
     }
 }
 
-tasks.register("format") {
+val format = tasks.register("format") {
     group = "creek"
     description = "Format the code"
 
     dependsOn("spotlessCheck", "spotlessApply")
 }
 
-tasks.register("static") {
+val static = tasks.register("static") {
     group = "creek"
     description = "Run static code analysis"
 
     dependsOn("checkstyleMain", "checkstyleTest", "spotbugsMain", "spotbugsTest")
+
+    shouldRunAfter(format)
+}
+
+tasks.test {
+    shouldRunAfter(static)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,12 +14,4 @@
 # limitations under the License.
 #
 
-junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = concurrent
-junit.jupiter.execution.parallel.mode.classes.default = concurrent
-junit.jupiter.execution.parallel.config.strategy = fixed
-# GitHub's runners only have two cores:
-# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-junit.jupiter.execution.parallel.config.fixed.parallelism = 2
-junit.jupiter.execution.parallel.config.fixed.max-pool-size = 4
-
+org.gradle.parallel=true


### PR DESCRIPTION
- add toolchain resolver
- turn off junit parallel testing: Because it really doesn't make much positive difference if Gradle is running in parallel mode with a decent number of test forks. On the downside, turning it on can cause some time-sensitive tests to fail, because they get starved.

Gradle parallel is much better, as it takes into account core count!
