### PR TITLE
fix: escape backslashes in gradle.properties JVM args on Windows

### DIFF
--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/TaskTestBase.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/TaskTestBase.java
@@ -113,7 +113,8 @@ public abstract class TaskTestBase {
         if (!options.isEmpty()) {
             TestPaths.write(
                     projectDir.resolve("gradle.properties"),
-                    "org.gradle.jvmargs=" + String.join(" ", options));
+                    "org.gradle.jvmargs="
+                            + String.join(" ", options).replace("\\", "\\\\"));
         }
     }
 


### PR DESCRIPTION
## Root Cause

On Windows, the `codeCoverageCmdLineArg(BUILD_DIR)` method returns a JVM argument string containing Windows paths with backslashes (e.g. `-javaagent:D:\a\...\build\...\jacocoagent.jar=destfile=D:\a\...\build\jacoco/test.exec,...`).

This string is written verbatim to `gradle.properties` as `org.gradle.jvmargs=...`. However, the Java `.properties` file format treats backslash as an escape character. As a result, paths like `D:\a\build` are read back as `D:abuild`, making the jacoco agent JAR path invalid.

This causes the Gradle daemon for functional test sub-builds to fail to start with:
```
Error opening zip file or JAR manifest missing : D:acreek-system-test-gradle-plugin...build
Error occurred during initialization of VM
agent library failed to init: instrument
```

## Fix

Escape backslashes in the JVM args string before writing to `gradle.properties`, replacing each `\` with `\\\\`. When Gradle reads the properties file, it unescapes `\\\\` back to `\`, producing the correct Windows path.

Fixes the failing `build_windows` job in run [24581564535](https://github.com/creek-service/creek-system-test-gradle-plugin/actions/runs/24581564535).