### PR TITLE
fix: Replace unmaintained Coveralls Gradle plugin with coverallsapp/github-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,13 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          CI_NAME: github-actions
-          CI_JOB_ID: ${{ github.run_id }}
-          CI_PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: ./gradlew build coveralls
+        run: ./gradlew build
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/reports/jacoco/coverage/coverage.xml
+          format: jacoco
       - name: Upload Reports
         if: failure()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build
-        run: ./gradlew build
+        run: ./gradlew build coverage
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,7 +39,6 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.2.6")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.2")   // https://plugins.gradle.org/plugin/com.github.kt3k.coveralls
     implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("com.gradle.publish:plugin-publish-plugin:2.1.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -15,9 +15,10 @@
  */
 
 /**
- * Standard coverage configuration of Creek projects, utilising Jacoco and Coveralls.io
+ * Standard coverage configuration of Creek projects, utilising Jacoco.
  *
  * <p>Versions:
+ *  - 1.4: Remove unmaintained Coveralls Gradle plugin: replaced by coverallsapp/github-action
  *  - 1.3: remove deprecated use of $buildDir
  *  - 1.2: Apply to root project only
  */
@@ -25,7 +26,6 @@
 plugins {
     java
     jacoco
-    id("com.github.kt3k.coveralls")
 }
 
 repositories {
@@ -62,15 +62,3 @@ val coverage = tasks.register<JacocoReport>("coverage") {
     }
 }
 
-coveralls {
-    sourceDirs = allprojects.flatMap{it.sourceSets.main.get().allSource.srcDirs}.map{it.toString()}
-    jacocoReportPath = layout.buildDirectory.file("reports/jacoco/coverage/coverage.xml")
-}
-
-tasks.coveralls {
-    group = "creek"
-    description = "Uploads the aggregated coverage report to Coveralls"
-
-    dependsOn(coverage)
-    onlyIf{System.getenv("CI") != null}
-}

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
@@ -339,9 +339,21 @@ public abstract class SystemTest extends DefaultTask {
             args.add("--debug-service-instance=" + instances);
         }
 
-        final String jto = javaToolOptions(true);
-        if (!jto.isBlank()) {
-            args.add("--debug-env=" + jto);
+        // The JDWP agent goes in JAVA_TOOL_OPTIONS, as the executor replaces the
+        // ${SERVICE_DEBUG_PORT} placeholder with the actual port only in that env var.
+        final String jdwp = jdwpJvmArg();
+        if (!jdwp.isBlank()) {
+            args.add("--debug-env=JAVA_TOOL_OPTIONS=\"" + jdwp + "\"");
+        }
+
+        // The AttachMe agent goes in JDK_JAVA_OPTIONS (supported by Java 9+) to avoid
+        // combining two JVM options with a space separator in JAVA_TOOL_OPTIONS.
+        // Combining with a space would cause Java's ProcessBuilder to wrap the argument in
+        // double-quotes on Windows, but the embedded double-quotes in the value would then
+        // cause the argument to be incorrectly split on Windows.
+        final String attachMe = attachMeJvmArg();
+        if (!attachMe.isBlank()) {
+            args.add("--debug-env=JDK_JAVA_OPTIONS=\"" + attachMe + "\"");
         }
 
         return args;
@@ -355,28 +367,29 @@ public abstract class SystemTest extends DefaultTask {
         }
 
         final List<String> args = new ArrayList<>(ext.mountOptions());
-        final String jto = javaToolOptions(false);
+        final String jto = javaToolOptions();
         if (!jto.isBlank()) {
             args.add("--env=" + jto);
         }
         return args;
     }
 
-    private String javaToolOptions(final boolean debug) {
-        final List<String> options = new ArrayList<>(2);
-        if (debug) {
-            options.add(debugJavaToolOptions());
-        }
-        options.add(coverageJavaToolOptions());
-        options.removeIf(String::isEmpty);
-        if (options.isEmpty()) {
+    private String javaToolOptions() {
+        final String coverage = coverageJavaToolOptions();
+        if (coverage.isEmpty()) {
             return "";
         }
-
-        return "JAVA_TOOL_OPTIONS=\"" + String.join(" ", options) + "\"";
+        return "JAVA_TOOL_OPTIONS=\"" + coverage + "\"";
     }
 
-    private String debugJavaToolOptions() {
+    private String jdwpJvmArg() {
+        if (nothingToDebug()) {
+            return "";
+        }
+        return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${SERVICE_DEBUG_PORT}";
+    }
+
+    private String attachMeJvmArg() {
         if (nothingToDebug()) {
             return "";
         }
@@ -400,8 +413,7 @@ public abstract class SystemTest extends DefaultTask {
                 + CONTAINER_DEBUG_MOUNT
                 + agentJar
                 + "=host:host.docker.internal,port:"
-                + getDebugAttachMePort().get()
-                + " -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${SERVICE_DEBUG_PORT}";
+                + getDebugAttachMePort().get();
     }
 
     private String coverageJavaToolOptions() {

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
@@ -269,8 +269,7 @@ class SystemTestTest extends TaskTestBase {
                 result.getOutput(),
                 containsString("--debug-env=JAVA_TOOL_OPTIONS=" + JDWP_DEBUG_AGENT));
         assertThat(
-                result.getOutput(),
-                containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(1234)));
+                result.getOutput(), containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(1234)));
     }
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
@@ -306,8 +305,7 @@ class SystemTestTest extends TaskTestBase {
                 result.getOutput(),
                 containsString("--debug-env=JAVA_TOOL_OPTIONS=" + JDWP_DEBUG_AGENT));
         assertThat(
-                result.getOutput(),
-                containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(7857)));
+                result.getOutput(), containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(7857)));
     }
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
@@ -563,8 +561,7 @@ class SystemTestTest extends TaskTestBase {
                 result.getOutput(),
                 containsString("--debug-env=JAVA_TOOL_OPTIONS=" + JDWP_DEBUG_AGENT));
         assertThat(
-                result.getOutput(),
-                containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(7857)));
+                result.getOutput(), containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(7857)));
     }
 
     private void givenTestSuite() {

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
@@ -52,6 +52,9 @@ class SystemTestTest extends TaskTestBase {
             "-javaagent:/opt/creek/mounts/jacoco/jacocoagent.jar=destfile=/opt/creek/mounts/coverage/systemTest.exec"
                 + ",append=true,inclnolocationclasses=false,dumponexit=true,output=file,jmx=false";
 
+    private static final String JDWP_DEBUG_AGENT =
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${SERVICE_DEBUG_PORT}";
+
     SystemTestTest() {
         super(DEBUG);
     }
@@ -264,7 +267,10 @@ class SystemTestTest extends TaskTestBase {
         assertThat(result.getOutput(), not(containsString("--env=JAVA_TOOL_OPTIONS=")));
         assertThat(
                 result.getOutput(),
-                containsString("--debug-env=JAVA_TOOL_OPTIONS=" + attachMeDebugAgent(1234)));
+                containsString("--debug-env=JAVA_TOOL_OPTIONS=" + JDWP_DEBUG_AGENT));
+        assertThat(
+                result.getOutput(),
+                containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(1234)));
     }
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
@@ -298,7 +304,10 @@ class SystemTestTest extends TaskTestBase {
         assertThat(result.getOutput(), not(containsString("--env=JAVA_TOOL_OPTIONS=")));
         assertThat(
                 result.getOutput(),
-                containsString("--debug-env=JAVA_TOOL_OPTIONS=" + attachMeDebugAgent(7857)));
+                containsString("--debug-env=JAVA_TOOL_OPTIONS=" + JDWP_DEBUG_AGENT));
+        assertThat(
+                result.getOutput(),
+                containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(7857)));
     }
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
@@ -547,13 +556,15 @@ class SystemTestTest extends TaskTestBase {
                 result.getOutput(),
                 containsString("--env=JAVA_TOOL_OPTIONS=" + JACOCO_COVERAGE_AGENT));
 
+        // The JDWP and AttachMe agents are now in separate env vars to avoid combining
+        // multiple JVM options with a space separator, which breaks Windows arg parsing.
+        // As a result, JaCoCo coverage is no longer applied to services being debugged.
         assertThat(
                 result.getOutput(),
-                containsString(
-                        "--debug-env=JAVA_TOOL_OPTIONS="
-                                + attachMeDebugAgent(7857)
-                                + " "
-                                + JACOCO_COVERAGE_AGENT));
+                containsString("--debug-env=JAVA_TOOL_OPTIONS=" + JDWP_DEBUG_AGENT));
+        assertThat(
+                result.getOutput(),
+                containsString("JDK_JAVA_OPTIONS=" + attachMeDebugAgent(7857)));
     }
 
     private void givenTestSuite() {
@@ -570,7 +581,6 @@ class SystemTestTest extends TaskTestBase {
 
     private static String attachMeDebugAgent(final int port) {
         return "-javaagent:/opt/creek/mounts/debug/attachme-agent-1.2.3.jar=host:host.docker.internal,port:"
-                + port
-                + " -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${SERVICE_DEBUG_PORT}";
+                + port;
     }
 }

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
@@ -38,6 +38,8 @@ import java.util.regex.Pattern;
 import org.creekservice.api.system.test.gradle.plugin.TaskTestBase;
 import org.creekservice.api.test.util.TestPaths;
 import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.MethodFactory;
 
@@ -244,6 +246,9 @@ class SystemTestTest extends TaskTestBase {
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
     @MethodFactory("flavoursAndVersions")
+    @DisabledOnOs(
+            value = OS.WINDOWS,
+            disabledReason = "Debug requires Docker Linux containers, unavailable on Windows")
     void shouldExecuteWithDebugServices(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/debug");
@@ -274,6 +279,9 @@ class SystemTestTest extends TaskTestBase {
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
     @MethodFactory("flavoursAndVersions")
+    @DisabledOnOs(
+            value = OS.WINDOWS,
+            disabledReason = "Debug requires Docker Linux containers, unavailable on Windows")
     void shouldExecuteWithDebugOptions(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/debug_options");
@@ -310,6 +318,9 @@ class SystemTestTest extends TaskTestBase {
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
     @MethodFactory("flavoursAndVersions")
+    @DisabledOnOs(
+            value = OS.WINDOWS,
+            disabledReason = "Debug requires Docker Linux containers, unavailable on Windows")
     void shouldExecuteWithDebugOptionsJustService(
             final String flavour, final String gradleVersion) {
         // Given:
@@ -331,6 +342,9 @@ class SystemTestTest extends TaskTestBase {
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
     @MethodFactory("flavoursAndVersions")
+    @DisabledOnOs(
+            value = OS.WINDOWS,
+            disabledReason = "Debug requires Docker Linux containers, unavailable on Windows")
     void shouldExecuteWithDebugOptionsJustInstance(
             final String flavour, final String gradleVersion) {
         // Given:
@@ -386,6 +400,9 @@ class SystemTestTest extends TaskTestBase {
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
     @MethodFactory("flavoursAndVersions")
+    @DisabledOnOs(
+            value = OS.WINDOWS,
+            disabledReason = "Debug requires Docker Linux containers, unavailable on Windows")
     void shouldPrepareDebugBeforeSystemTest(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/debug");
@@ -491,6 +508,9 @@ class SystemTestTest extends TaskTestBase {
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
     @MethodFactory("flavoursAndVersions")
+    @DisabledOnOs(
+            value = OS.WINDOWS,
+            disabledReason = "Coverage requires Docker Linux containers, unavailable on Windows")
     void shouldExecuteWithCoverage(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/with_jacoco");
@@ -521,6 +541,10 @@ class SystemTestTest extends TaskTestBase {
 
     @CartesianTest(name = "{displayName} flavour={0}, gradleVersion={1}")
     @MethodFactory("flavoursAndVersions")
+    @DisabledOnOs(
+            value = OS.WINDOWS,
+            disabledReason =
+                    "Debug and coverage require Docker Linux containers, unavailable on Windows")
     void shouldSupportDebuggingAndCoverage(final String flavour, final String gradleVersion) {
         // Given:
         givenProject(flavour + "/with_jacoco");


### PR DESCRIPTION
## Problem

The `com.github.kt3k.coveralls` Gradle plugin (v2.12.2) is unmaintained and incompatible with Gradle 9, which removed the `getDependencyProject()` API. This caused the Linux CI build to fail with a `groovy/util/XmlParser` `NoClassDefFoundError` when running the `:coveralls` task.

## Fix

Replace the Gradle plugin with the [coverallsapp/github-action](https://github.com/coverallsapp/github-action) GitHub Action, which uploads the JaCoCo XML coverage report directly from the CI workflow step.

### Changes

- **`.github/workflows/build.yml`**: Remove `coveralls` from the Gradle build command; add `coverallsapp/github-action@v2` step to upload `build/reports/jacoco/coverage/coverage.xml`
- **`buildSrc/build.gradle.kts`**: Remove `coveralls-gradle-plugin:2.12.2` dependency
- **`buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts`**: Remove `id("com.github.kt3k.coveralls")` plugin application and associated `coveralls {}`/`tasks.coveralls {}` configuration