### PR TITLE
ci: temporarily disable build_windows job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,9 @@ jobs:
           ./gradlew -Dgradle.publish.key="$GRADLE_PUBLISH_KEY" -Dgradle.publish.secret="$GRADLE_PUBLISH_SECRET" publishPlugins
 
   # Until Creek fully supports Windows, minimal check:
+  # Temporarily disabled: remove the `if: false` line to re-enable
   build_windows:
+    if: false
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Temporarily disables the `build_windows` job in the main build workflow.

To re-enable, remove the `if: false` line from the `build_windows` job in `.github/workflows/build.yml`.