### PR TITLE
docs: replace Coveralls badge with Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/org.creekservice.system.test?label=Gradle%20Plugin%20Portal)](https://plugins.gradle.org/plugin/org.creekservice.system.test)
 [![build](https://github.com/creek-service/creek-system-test-gradle-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/creek-service/creek-system-test-gradle-plugin/actions/workflows/build.yml)
-[![Coverage Status](https://coveralls.io/repos/github/creek-service/creek-system-test-gradle-plugin/badge.svg?branch=main)](https://coveralls.io/github/creek-service/creek-system-test-gradle-plugin?branch=main)
+[![codecov](https://codecov.io/gh/creek-service/creek-system-test-gradle-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/creek-service/creek-system-test-gradle-plugin)
 [![CodeQL](https://github.com/creek-service/creek-system-test-gradle-plugin/actions/workflows/codeql.yml/badge.svg)](https://github.com/creek-service/creek-system-test-gradle-plugin/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/creek-service/creek-system-test-gradle-plugin/badge)](https://api.securityscorecards.dev/projects/github.com/creek-service/creek-system-test-gradle-plugin)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6899/badge)](https://bestpractices.coreinfrastructure.org/projects/6899)


### PR DESCRIPTION
## Summary

Replace the Coveralls.io coverage badge with the equivalent Codecov badge, following the migration from Coveralls to Codecov in https://github.com/creek-service/creek-release-test/pull/411.