### PR TITLE
chore: align buildSrc with Creek estate

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
+    implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("com.gradle.publish:plugin-publish-plugin:2.1.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,8 +38,8 @@ kotlin {
 
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
+    implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("com.gradle.publish:plugin-publish-plugin:2.1.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 }


### PR DESCRIPTION
Aligns buildSrc with the rest of the Creek estate:
- spotless-plugin-gradle 7.2.1 → 8.4.0 (where applicable)
- org.javamodularity:moduleplugin 1.8.x → 2.0.0 (where applicable)
- spotbugs-gradle-plugin updates (where applicable)
- Convention script alignment: findsecbugs, checkstyle version, forkEvery, spotbugs XML reports, shouldRunAfter task ordering, snapshot repo, group ID