### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@
   <!-- See https://checkstyle.org/config_header.html   -->
   <module name="RegexpHeader">
     <property name="header"
-            value="/\*\n\* Copyright (\d\d\d\d-)?2025 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
+            value="/\*\n\* Copyright (\d\d\d\d-)?2026 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
   </module>
 
   <module name="TreeWalker">

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/spotbugs/suppressions.xml
+++ b/config/spotbugs/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/DebugExtension.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/DebugExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestExtension.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestPlugin.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/SystemTestPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/coverage/PrepareCoverage.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/coverage/PrepareCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/coverage/SystemTestCoverageExtension.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/coverage/SystemTestCoverageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/debug/AttachMeAgentJarFinder.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/debug/AttachMeAgentJarFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/debug/PrepareDebug.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/debug/PrepareDebug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
+++ b/src/main/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/ModuleTest.java
+++ b/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/ExecutorVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/TaskTestBase.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/TaskTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/coverage/PrepareCoverageTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/coverage/PrepareCoverageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/debug/AttachMeAgentJarFinderTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/debug/AttachMeAgentJarFinderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/debug/PrepareDebugTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/debug/PrepareDebugTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
+++ b/src/test/java/org/creekservice/api/system/test/gradle/plugin/test/SystemTestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/jacoco_report/build.gradle
+++ b/src/test/resources/projects/functional/groovy/jacoco_report/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/jacoco_report/service-module/build.gradle
+++ b/src/test/resources/projects/functional/groovy/jacoco_report/service-module/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/groovy/jacoco_report/sub-project/build.gradle
+++ b/src/test/resources/projects/functional/groovy/jacoco_report/sub-project/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/jacoco_report/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/jacoco_report/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/jacoco_report/service-module/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/jacoco_report/service-module/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/jacoco_report/sub-project/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/jacoco_report/sub-project/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/projects/functional/kotlin/with_jacoco/build.gradle.kts
+++ b/src/test/resources/projects/functional/kotlin/with_jacoco/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.creekservice.api.system.test.gradle.plugin.debug.PrepareDebug
 
 /*
- * Copyright 2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update checkstyle header rule and existing copyright headers from 2025 to 2026.

Note: `./gradlew static` was not fully verifiable locally as test compilation requires SNAPSHOT dependencies that are not yet published (this is expected during active development). The `checkstyleMain` task passed successfully.